### PR TITLE
[Report] 리포트 전송

### DIFF
--- a/src/app/(main)/pt-management/monthly/page.tsx
+++ b/src/app/(main)/pt-management/monthly/page.tsx
@@ -9,6 +9,8 @@ import { PageHeader } from '@/components/common/page-header';
 import { Session } from '@/features/session/types/session';
 import { useAssignments } from '@/features/assignment/hooks/use-assignments';
 import { useStudents } from '@/features/student/hooks/use-students';
+import { CreateReportModal } from '@/features/report/components/create-report-modal';
+import { Toast, useToast } from '@/components/common/toast';
 import { TrendingUp, FileText } from 'lucide-react';
 import dayjs from 'dayjs';
 
@@ -50,11 +52,13 @@ function StudentContent({
   studentName,
   selectedSession,
   onSelectSession,
+  onOpenReport,
 }: {
   studentId: string;
   studentName: string;
   selectedSession: Session | null;
   onSelectSession: (session: Session) => void;
+  onOpenReport: () => void;
 }) {
   const { data: assignments = [] } = useAssignments({
     sessionId: selectedSession?.id,
@@ -70,7 +74,6 @@ function StudentContent({
 
   return (
     <>
-      {/* 학생 정보 헤더 */}
       <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
         <div className="flex items-center gap-3">
           <span className="text-xl font-bold text-gray-900">{studentName}</span>
@@ -80,14 +83,16 @@ function StudentContent({
             <TrendingUp size={12} />
             성적 확인 연동
           </button>
-          <button className="flex items-center gap-1.5 rounded bg-blue-500 px-3 py-1.5 text-xs text-white hover:bg-blue-600">
+          <button
+            onClick={onOpenReport}
+            className="flex items-center gap-1.5 rounded bg-blue-500 px-3 py-1.5 text-xs text-white hover:bg-blue-600"
+          >
             <FileText size={12} />
             리포트 전송
           </button>
         </div>
       </div>
 
-      {/* KPI 카드 */}
       <div className="flex gap-3 border-b border-gray-100 px-6 py-4">
         <KpiCard
           label="과제 달성률"
@@ -104,13 +109,11 @@ function StudentContent({
         <KpiCard label="재등록 월" value={enrollMonth} color="purple" />
       </div>
 
-      {/* 세션 네비게이터 */}
       <div className="flex items-center justify-between border-b border-gray-100 px-6 py-3">
         <h2 className="text-sm font-semibold text-gray-900">일별 관리 세션</h2>
         <SessionNavigator onSelectSession={onSelectSession} />
       </div>
 
-      {/* 과제 테이블 */}
       {selectedSession ? (
         <DailySessionTable
           sessionId={selectedSession.id}
@@ -125,10 +128,15 @@ function StudentContent({
   );
 }
 
-function MonthlyContent() {
+function MonthlyContent({
+  showToast,
+}: {
+  showToast: (message: string, type?: 'success' | 'error') => void;
+}) {
   const searchParams = useSearchParams();
   const studentId = searchParams.get('studentId');
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
+  const [reportModalOpen, setReportModalOpen] = useState(false);
 
   const { data: students = [] } = useStudents({
     organizationId: '11111111-1111-1111-1111-111111111111',
@@ -155,6 +163,7 @@ function MonthlyContent() {
               studentName={selectedStudent?.name ?? ''}
               selectedSession={selectedSession}
               onSelectSession={handleSelectSession}
+              onOpenReport={() => setReportModalOpen(true)}
             />
           ) : (
             <div className="flex flex-1 items-center justify-center text-sm text-gray-400">
@@ -163,14 +172,32 @@ function MonthlyContent() {
           )}
         </div>
       </div>
+
+      {studentId && (
+        <CreateReportModal
+          open={reportModalOpen}
+          onClose={() => setReportModalOpen(false)}
+          studentId={studentId}
+          sessionId={selectedSession?.id ?? null}
+          onSuccess={() => showToast('리포트 전송이 완료되었습니다.')}
+        />
+      )}
     </div>
   );
 }
 
 export default function MonthlyPage() {
+  const { toast, showToast, hideToast } = useToast();
+
   return (
-    <Suspense>
-      <MonthlyContent />
-    </Suspense>
+    <>
+      <Suspense>
+        <MonthlyContent showToast={showToast} />
+      </Suspense>
+
+      {toast && (
+        <Toast message={toast.message} type={toast.type} onClose={hideToast} />
+      )}
+    </>
   );
 }

--- a/src/components/common/toast.tsx
+++ b/src/components/common/toast.tsx
@@ -13,7 +13,12 @@ type Props = {
   onClose: () => void;
 };
 
-export function Toast({ message, type = 'success', duration = 3000, onClose }: Props) {
+export function Toast({
+  message,
+  type = 'success',
+  duration = 3000,
+  onClose,
+}: Props) {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -41,7 +46,10 @@ export function Toast({ message, type = 'success', duration = 3000, onClose }: P
         <XCircle size={16} className="text-red-500" />
       )}
       <span>{message}</span>
-      <button onClick={onClose} className="ml-2 text-gray-400 hover:text-gray-600">
+      <button
+        onClick={onClose}
+        className="ml-2 text-gray-400 hover:text-gray-600"
+      >
         <X size={14} />
       </button>
     </div>
@@ -49,7 +57,10 @@ export function Toast({ message, type = 'success', duration = 3000, onClose }: P
 }
 
 export function useToast() {
-  const [toast, setToast] = useState<{ message: string; type: ToastType } | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: ToastType;
+  } | null>(null);
 
   const showToast = (message: string, type: ToastType = 'success') => {
     setToast({ message, type });

--- a/src/features/report/api/create-report.ts
+++ b/src/features/report/api/create-report.ts
@@ -1,0 +1,8 @@
+import { apiClient } from '@/lib/api/client';
+import { CreateReportRequest } from '../types/report';
+import { ENDPOINTS } from '@/lib/api/endpoints';
+
+export async function createReport(data: CreateReportRequest): Promise<Report> {
+  const res = await apiClient.post(ENDPOINTS.REPORTS, data);
+  return res.data;
+}

--- a/src/features/report/components/create-report-modal.tsx
+++ b/src/features/report/components/create-report-modal.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Modal } from '@/components/common/modal';
+import { useCreateReport } from '../hooks/use-create-report';
+
+const schema = z.object({
+  fromAt: z.string().min(1, '시작일을 선택해주세요.'),
+  toAt: z.string().min(1, '종료일을 선택해주세요.'),
+  summary: z.string().min(1, '요약을 입력해주세요.'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  studentId: string;
+  sessionId?: string | null;
+  onSuccess?: () => void;
+};
+
+export function CreateReportModal({
+  open,
+  onClose,
+  studentId,
+  sessionId,
+  onSuccess,
+}: Props) {
+  const { mutate, isPending } = useCreateReport();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    mutate(
+      {
+        studentId,
+        sessionId: sessionId ?? null,
+        fromAt: new Date(values.fromAt).toISOString(),
+        toAt: new Date(values.toAt + 'T23:59:59').toISOString(),
+        summary: values.summary,
+      },
+      {
+        onSuccess: () => {
+          reset();
+          onClose();
+          onSuccess?.();
+        },
+      },
+    );
+  });
+
+  return (
+    <Modal open={open} onClose={onClose} title="리포트 전송">
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">
+              시작일 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="date"
+              {...register('fromAt')}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+            />
+            {errors.fromAt && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.fromAt.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">
+              종료일 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="date"
+              {...register('toAt')}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+            />
+            {errors.toAt && (
+              <p className="mt-1 text-xs text-red-500">{errors.toAt.message}</p>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600">
+            요약 <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            {...register('summary')}
+            rows={4}
+            placeholder="이번 달 학습 현황 요약을 입력해주세요."
+            className="w-full resize-none rounded border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          />
+          {errors.summary && (
+            <p className="mt-1 text-xs text-red-500">
+              {errors.summary.message}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+              onClose();
+            }}
+            className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            disabled={isPending}
+            className="rounded bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600 disabled:opacity-50"
+          >
+            {isPending ? '전송 중...' : '전송'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/features/report/hooks/use-create-report.ts
+++ b/src/features/report/hooks/use-create-report.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { CreateReportRequest } from '../types/report';
+import { createReport } from '../api/create-report';
+
+export function useCreateReport() {
+  return useMutation({
+    mutationFn: (data: CreateReportRequest) => createReport(data),
+  });
+}

--- a/src/features/report/types/report.ts
+++ b/src/features/report/types/report.ts
@@ -1,0 +1,20 @@
+export type CreateReportRequest = {
+  studentId: string;
+  sessionId?: string | null;
+  fromAt: string;
+  toAt: string;
+  summary: string;
+};
+
+export type Report = {
+  id: string;
+  organizationId: string;
+  studentId: string;
+  sessionId: string | null;
+  fromAt: string;
+  toAt: string;
+  summary: string;
+  status: 'REQUESTED' | 'GENERATED' | 'SENT';
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## 관련 이슈

close #15

## 작업 내용

리포트 전송 버튼 구현 및 API 연동

## 세부 작업

- report.ts — Report 타입 정의
- create-report.ts — POST /reports API 추가
- useCreateReport 훅 추가
- CreateReportModal — 리포트 전송 모달 (RHF + Zod)
- 전송 완료 후 토스트 알림
- 월간 관리 페이지 리포트 전송 버튼 연동

## 참고

PDF 생성은 별도 서비스/라이브러리 연동 예정 (현재 메타데이터 저장만 구현)